### PR TITLE
Update Prow to v20220331-c4e1c201d5

### DIFF
--- a/config/jobs-variable/test-infra/presubmits.yaml
+++ b/config/jobs-variable/test-infra/presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20211216-b5865074c4
+      - image: gcr.io/k8s-prow/checkconfig:v20220331-c4e1c201d5
         command:
         - /checkconfig
         args:

--- a/config/jobs/test-infra/andy-infra.trusted.master.yaml
+++ b/config/jobs/test-infra/andy-infra.trusted.master.yaml
@@ -39,7 +39,7 @@ periodics:
     base_ref: main
   spec:
     containers:
-    - image: gcr.io/k8s-prow/generic-autobumper:v20220330-40eb179576
+    - image: gcr.io/k8s-prow/generic-autobumper:v20220331-c4e1c201d5
       command:
       - generic-autobumper
       args:

--- a/config/jobs/test-infra/presubmits.yaml
+++ b/config/jobs/test-infra/presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20211216-b5865074c4
+      - image: gcr.io/k8s-prow/checkconfig:v20220331-c4e1c201d5
         command:
         - /checkconfig
         args:

--- a/config/prow-variable/cluster/crier.yaml
+++ b/config/prow-variable/cluster/crier.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/crier:v20220331-c4e1c201d5
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow-variable/cluster/deck.yaml
+++ b/config/prow-variable/cluster/deck.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/deck:v20220331-c4e1c201d5
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow-variable/cluster/ghproxy.yaml
+++ b/config/prow-variable/cluster/ghproxy.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/ghproxy:v20220331-c4e1c201d5
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow-variable/cluster/hook.yaml
+++ b/config/prow-variable/cluster/hook.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/hook:v20220331-c4e1c201d5
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow-variable/cluster/horologium.yaml
+++ b/config/prow-variable/cluster/horologium.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/horologium:v20220331-c4e1c201d5
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/config/prow-variable/cluster/prow-controller-manager.yaml
+++ b/config/prow-variable/cluster/prow-controller-manager.yaml
@@ -39,7 +39,7 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
-        image: gcr.io/k8s-prow/prow-controller-manager:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220331-c4e1c201d5
         volumeMounts:
         - name: kubeconfig
           mountPath: /etc/kubeconfig

--- a/config/prow-variable/cluster/sinker.yaml
+++ b/config/prow-variable/cluster/sinker.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20220323-f964c2fa00 
+        image: gcr.io/k8s-prow/sinker:v20220331-c4e1c201d5 
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow-variable/cluster/statusreconciler.yaml
+++ b/config/prow-variable/cluster/statusreconciler.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/status-reconciler:v20220331-c4e1c201d5
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/config/prow-variable/cluster/tide.yaml
+++ b/config/prow-variable/cluster/tide.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/tide:v20220331-c4e1c201d5
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/config/prow-variable/config.yaml
+++ b/config/prow-variable/config.yaml
@@ -8,10 +8,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20211203-281e29a97a"
-        initupload: "gcr.io/k8s-prow/initupload:v20211203-281e29a97a"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20211203-281e29a97a"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20211203-281e29a97a"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220331-c4e1c201d5"
+        initupload: "gcr.io/k8s-prow/initupload:v20220331-c4e1c201d5"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220331-c4e1c201d5"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220331-c4e1c201d5"
       gcs_configuration:
         bucket: GCS_BUCKET
         path_strategy: "explicit"

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/crier:v20220331-c4e1c201d5
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/deck:v20220331-c4e1c201d5
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/ghproxy:v20220331-c4e1c201d5
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/hook:v20220331-c4e1c201d5
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/horologium:v20220331-c4e1c201d5
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
-        image: gcr.io/k8s-prow/prow-controller-manager:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220331-c4e1c201d5
         volumeMounts:
         - name: kubeconfig
           mountPath: /etc/kubeconfig

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20220323-9b8611d021
+        image: gcr.io/k8s-prow/sinker:v20220331-c4e1c201d5
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/status-reconciler:v20220331-c4e1c201d5
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20211203-281e29a97a
+        image: gcr.io/k8s-prow/tide:v20220331-c4e1c201d5
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -8,10 +8,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20211203-281e29a97a"
-        initupload: "gcr.io/k8s-prow/initupload:v20211203-281e29a97a"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20211203-281e29a97a"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20211203-281e29a97a"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220331-c4e1c201d5"
+        initupload: "gcr.io/k8s-prow/initupload:v20220331-c4e1c201d5"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220331-c4e1c201d5"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220331-c4e1c201d5"
       gcs_configuration:
         bucket: andytauber-prow
         path_strategy: "explicit"

--- a/infra/aws/utils/config-bootstrap-job.yaml
+++ b/infra/aws/utils/config-bootstrap-job.yaml
@@ -21,7 +21,7 @@ spec:
           mountPath: /andy-infra
       containers:
       - name: prow-config-bootstrapper
-        image: gcr.io/k8s-prow/config-bootstrapper:v20220330-0793228920
+        image: gcr.io/k8s-prow/config-bootstrapper:v20220331-c4e1c201d5
         args:
         - --dry-run=false
         - --source-path=/andy-infra


### PR DESCRIPTION
Multiple distinct gcr.io/k8s-prow/ changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/AndyTauber/andy-infra/compare/281e29a97a...c4e1c201d5 | 2021&#x2011;12&#x2011;03&nbsp;&#x2192;&nbsp;2022&#x2011;03&#x2011;31 | clonerefs, crier, deck, entrypoint, ghproxy, hook, horologium, initupload, prow-controller-manager, sidecar, status-reconciler, tide
https://github.com/AndyTauber/andy-infra/compare/b5865074c4...c4e1c201d5 | 2021&#x2011;12&#x2011;16&nbsp;&#x2192;&nbsp;2022&#x2011;03&#x2011;31 | checkconfig
https://github.com/AndyTauber/andy-infra/compare/9b8611d021...c4e1c201d5 | 2022&#x2011;03&#x2011;23&nbsp;&#x2192;&nbsp;2022&#x2011;03&#x2011;31 | sinker
https://github.com/AndyTauber/andy-infra/compare/f964c2fa00...c4e1c201d5 | 2022&#x2011;03&#x2011;23&nbsp;&#x2192;&nbsp;2022&#x2011;03&#x2011;31 | sinker
https://github.com/AndyTauber/andy-infra/compare/40eb179576...c4e1c201d5 | 2022&#x2011;03&#x2011;30&nbsp;&#x2192;&nbsp;2022&#x2011;03&#x2011;31 | generic-autobumper
https://github.com/AndyTauber/andy-infra/compare/0793228920...c4e1c201d5 | 2022&#x2011;03&#x2011;30&nbsp;&#x2192;&nbsp;2022&#x2011;03&#x2011;31 | config-bootstrapper



/cc

