### PR TITLE
TCE: Fix test spec

### DIFF
--- a/config/jobs/tce/tce-testing-presubmit.yaml
+++ b/config/jobs/tce/tce-testing-presubmit.yaml
@@ -1,15 +1,10 @@
 ---
 postsubmits:
   AndyTauber/andy-infra:
-    - name: Running-TCE-Package-test
+    - name: running-tce-package-test
       cluster: prow-service-trusted
-      interval: 4h
-      always_run: true
       decorate: true
       run_if_changed: 'config/jobs/tce'
-      annotations:
-        testgrid-dashboards: tce
-        testgrid-tab-name: periodics
       clone_uri: git@github.com:vmware-tanzu/community-edition.git
       spec:
         containers:


### PR DESCRIPTION
Remove incompatible fields for the prowjobs

```bash
2022-08-09T10:15:51Z{component: prow-controller-manager, error: job Running-TCE-Package-test is set to always run but also declares run_if_changed targets, which are mutually exclusive, file: k8s.io/test-infra/prow/cmd/prow-controller-manager/main.go:126, func: main.main, level: fatal, msg: Error starting config agent.…
```