### PR TITLE
Enable workload identiy and split clusters configuration

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/crier:v20220810-a8a8778c45
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/crier_rbac.yaml
+++ b/config/prow/cluster/crier_rbac.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 metadata:
   name: crier
   namespace: prow
+  annotations:
+    iam.gke.io/gcp-service-account: "control-plane@prow-open-btr.iam.gserviceaccount.com"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/deck:v20220810-a8a8778c45
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/deck_rbac.yaml
+++ b/config/prow/cluster/deck_rbac.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 metadata:
   namespace: prow
   name: "deck"
+  annotations:
+    iam.gke.io/gcp-service-account: "control-plane@prow-open-btr.iam.gserviceaccount.com"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/ghproxy_deployment.yaml
+++ b/config/prow/cluster/ghproxy_deployment.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/ghproxy:v20220810-a8a8778c45
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/hook:v20220810-a8a8778c45
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/hook_rbac.yaml
+++ b/config/prow/cluster/hook_rbac.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   namespace: prow
   name: "hook"
+  annotations:
+    iam.gke.io/gcp-service-account: "control-plane@prow-open-btr.iam.gserviceaccount.com"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -22,7 +22,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/horologium:v20220810-a8a8778c45
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/prow-controller-manager_deployment.yaml
+++ b/config/prow/cluster/prow-controller-manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
         ports:
         - name: metrics
           containerPort: 9090
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220810-a8a8778c45
         volumeMounts:
         - mountPath: /etc/kubeconfig-default
           name: kubeconfig-default

--- a/config/prow/cluster/prow-controller-manager_rbac.yaml
+++ b/config/prow/cluster/prow-controller-manager_rbac.yaml
@@ -4,6 +4,8 @@ kind: ServiceAccount
 metadata:
   namespace: prow
   name: prow-controller-manager
+  annotations:
+    iam.gke.io/gcp-service-account: "control-plane@prow-open-btr.iam.gserviceaccount.com"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/sinker:v20220810-a8a8778c45
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/sinker_rbac.yaml
+++ b/config/prow/cluster/sinker_rbac.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 metadata:
   namespace: prow
   name: "sinker"
+  annotations:
+    iam.gke.io/gcp-service-account: "control-plane@prow-open-btr.iam.gserviceaccount.com"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/status-reconciler:v20220810-a8a8778c45
         args:
         - --dry-run=false
         - --continue-on-error=true

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220331-c4e1c201d5
+        image: gcr.io/k8s-prow/tide:v20220810-a8a8778c45
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -3,15 +3,15 @@ plank:
     '*': https://prow.andytauber.info/view/
   pod_pending_timeout: 15m
   pod_unscheduled_timeout: 5m
-  default_decoration_configs:
-    '*':
+  default_decoration_config_entries:
+  - config:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220331-c4e1c201d5"
-        initupload: "gcr.io/k8s-prow/initupload:v20220331-c4e1c201d5"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220331-c4e1c201d5"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220331-c4e1c201d5"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220810-a8a8778c45"
+        initupload: "gcr.io/k8s-prow/initupload:v20220810-a8a8778c45"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220810-a8a8778c45"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220810-a8a8778c45"
       gcs_configuration:
         bucket: sandbox-gcs-publisher
         path_strategy: "explicit"
@@ -29,6 +29,12 @@ plank:
         sidecar:
           requests:
             cpu: 100m
+  - cluster: tkg-es-infra-prow-build
+    config:
+      gcs_credentials_secret: "" # Use workload identity
+      gcs_configuration:
+        bucket: "tkg-es-openbtr-prow"
+      default_service_account_name: "prowjob-default-sa"
 
 sinker:
   resync_period: 1m


### PR DESCRIPTION
  According to prow announcements,

  ```
  `plank.default_decoration_configs` can optionally be replaced with
  `plank.default_decoration_config_entries` which supports a new format
  that is a slice of filters with associated decoration configs rather than a
  map. Currently entries can filter by repo and/or cluster. The old field is still
  supported and will not be deprecated.
  ```

  The configuration is modified to use this field and ensure we can add more build clusters.

  - Add annotation to ensure k8s service accounts for prow components can use workload identity.
  - bump prow components version to the last version