### PR TITLE
Add a heartbeat job

### DIFF
--- a/config/jobs/extended-support/canaries.yaml
+++ b/config/jobs/extended-support/canaries.yaml
@@ -1,0 +1,23 @@
+periodics:
+- cron: "*/3 * * * *" # Every 3 minutes
+  name: ci-tkg-es-prow-build-heartbeat
+  decorate: true
+  cluster: tkg-es-infra-prow-build
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+  spec:
+    containers:
+    - image: alpine:latest
+      command:
+      - "echo"
+      args:
+      - "Everything is fine!"
+      resources:
+        limits:
+          cpu: 100m
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 1Gi


### PR DESCRIPTION
Add a periodic prowjob to ensure we can run jobs on the GKE cluster `tkg-es-infra-prow-build`.